### PR TITLE
fix: use timing-safe string comparison

### DIFF
--- a/src/XHubSignature.js
+++ b/src/XHubSignature.js
@@ -1,5 +1,7 @@
 import crypto from 'crypto'
 
+let encoder = new TextEncoder()
+
 export default class XHubSignature {
   #algorithm = null
   #secret = null
@@ -24,6 +26,12 @@ export default class XHubSignature {
   }
 
   verify (expectedSignature, requestBody) {
-    return expectedSignature === this.sign(requestBody)
+    const expected = encoder.encode(expectedSignature)
+    const actualSignature = this.sign(requestBody)
+    const actual = encoder.encode(signature)
+    if (expected.length !== actual.length) {
+      return false
+    }
+    return crypto.timingSafeEqual(expected, actual)
   }
 }


### PR DESCRIPTION
Updated to use `crypto.timingSafeEqual()`, similar to the updated example at <https://docs.github.com/en/webhooks-and-events/webhooks/securing-your-webhooks>.